### PR TITLE
Update PCD2 links and make markdownlint clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,59 @@
 # SMPTE _ST 2094-50_ - _Dynamic Metadata for Color Volume Transform - Application #5 (Broadcast)_
 
 ## General
-This repository tracks ST 2094-50 - Dynamic Metadata for Color Volume Transform - Application #5 (Broadcast)
 
-_This repository is *public*._
+This repository tracks ST 2094-50 - Dynamic Metadata for Color Volume
+Transform - Application #5 (Broadcast)
 
-Please consult [CONTRIBUTING.md](./CONTRIBUTING.md), [CONFIDENTIALITY.md](./CONFIDENTIALITY.md), [LICENSE.md](./LICENSE.md) and
+_This repository is **public**._
+
+Please consult [CONTRIBUTING.md](./CONTRIBUTING.md),
+[CONFIDENTIALITY.md](./CONFIDENTIALITY.md), [LICENSE.md](./LICENSE.md) and
 [PATENTS.md](./PATENTS.md) for important notices.
 
-Your feedback is welcome at https://github.com/SMPTE/st2094-50/issues.
+Your feedback is welcome at <https://github.com/SMPTE/st2094-50/issues>.
 
-## Public Committee Draft (PCD) Notice
-The Public Committee Draft (PCD) of ST 2094-50 is made available in 10e-st-2094-50-cd-2025-08-26-draft.zip for a review period ending no later than 2025-10-17.<br><br>
-To view the document, please download the [ZIP file](./10e-st-2094-50-cd-2025-08-26-draft.zip), extract the files, and open the HTML file in your browser.
+## Second Public Committee Draft (PCD2) Notice
+
+The second Public Committee Draft (PCD2) of ST 2094-50 is made available in
+10e-st-2094-50-cd-2026-02-23-draft.zip for a review period ending no later than
+2026-03-11.
+
+To view the document, please download the
+[ZIP file](./10e-st-2094-50-cd-2026-02-23-draft.zip), extract the files, and
+open the HTML file in your browser.
 
 ## Details
 
-In “Dynamic Metadata System for Color Volume Transform,” ST 2094-50 defines a standardized framework that enables modern operating systems, image compositors, and display pipelines to render multiple HDR and SDR sources - text, graphics, images, and video within a common color-volume architecture.<br>
+In “Dynamic Metadata System for Color Volume Transform,” ST 2094-50 defines a
+standardized framework that enables modern operating systems, image
+compositors, and display pipelines to render multiple HDR and SDR sources -
+text, graphics, images, and video within a common color-volume architecture.
 
-The system anchors rendering behavior around an explicitly defined HDR Reference White, carried within embedded dynamic metadata. By clearly identifying Reference White, content creators gain the flexibility to establish their intended artistic “look,” while also preserving perceptual intent across displays with widely varying peak luminance capabilities.<br>
+The system anchors rendering behavior around an explicitly defined HDR
+Reference White, carried within embedded dynamic metadata. By clearly
+identifying Reference White, content creators gain the flexibility to establish
+their intended artistic “look,” while also preserving perceptual intent across
+displays with widely varying peak luminance capabilities.
 
-ST 2094-50 addresses a long-standing challenge: consistent compositing of mixed HDR and SDR elements. Until now, such workflows have either required manual color management, been inconsistently implemented, or lacked predictable behavior across platforms—including web browsers, consumer televisions, and desktop displays. By standardizing dynamic color-volume transforms, ST 2094-50 provides a path toward interoperable, perceptually consistent HDR rendering in heterogeneous display environments. We look forward to your comments.<br>
+ST 2094-50 addresses a long-standing challenge: consistent compositing of mixed
+HDR and SDR elements. Until now, such workflows have either required manual
+color management, been inconsistently implemented, or lacked predictable
+behavior across platforms—including web browsers, consumer televisions, and
+desktop displays. By standardizing dynamic color-volume transforms, ST 2094-50
+provides a path toward interoperable, perceptually consistent HDR rendering in
+heterogeneous display environments. We look forward to your comments.
 
-**Implementers are encouraged to review the system and provide feedback as soon as possible but no later than October 17, 2025, via GitHub, to help improve the document and enhance interoperability across implementations.**
+**Implementers are encouraged to review the system and provide feedback as soon
+as possible but no later than March 11, 2026, via GitHub, to help improve the
+document and enhance interoperability across implementations.**
 
 ## Reporting issues
 
-Please report issues at <https://github.com/SMPTE/st2094-50/issues> or to 10E Chairs <10e-chair@smpte.org>.
+Please report issues at <https://github.com/SMPTE/st2094-50/issues> or to 10E
+Chairs <10e-chair@smpte.org>.
 
 ## Contributing
 
-The draft version(s) of this document is accessible to SMPTE Standards Community members at <https://github.com/SMPTE/st2094-50-private>.
+The draft version(s) of this document is accessible to SMPTE Standards Community
+members at <https://github.com/SMPTE/st2094-50-private>.


### PR DESCRIPTION
Update links to the PCD2 zip file, and update README.md to fix markdownlint errors.